### PR TITLE
Updated dependencies for iojs v3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: node_js
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
 node_js:
-  - 0.8
-  - 0.10
-  - 0.12
-  - iojs-v1
-  - iojs-v2
-  - iojs-v3
+  - "0.8"
+  - "0.10"
+  - "0.12"
+  - "iojs-1"
+  - "iojs-2"
+  - "iojs-3"
+before_install:
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - g++ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - 0.8
-  - "0.10"
-  - "0.12"
-  - "iojs-1"
-  - "iojs-2"
+  - 0.10
+  - 0.12
+  - iojs-v1
+  - iojs-v2
+  - iojs-v3

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "mocha": "~2.1.0"
   },
   "dependencies": {
-    "microtime": "~1.4.2",
+    "microtime": "~2.0.0",
     "atoll": "~0.7.3",
-    "async": "~0.9.0"
+    "async": "~1.4.2"
   },
   "optionalDependencies": {
     "nan": "~1.8.4"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "async": "~1.4.2"
   },
   "optionalDependencies": {
-    "nan": "~1.8.4"
+    "nan": "~2.0.5"
   }
 }


### PR DESCRIPTION
Previous microtime version was failing to build on iojs v3. This also produced a build conflict when installing mosca, so this PR is needed in order to prepare mosca for iojs v3 as well.
